### PR TITLE
removed KEY_COLUMN from table.py

### DIFF
--- a/table_tester.py
+++ b/table_tester.py
@@ -6,44 +6,45 @@ from template.table import *
 from template.index import Index
 from template.config import *
 
+
 class TestTableFunctionality(unittest.TestCase):
     def setUp(self):
         self.name = "grades"
-        self.key = 1234
+        self.key = 0
         self.num_columns = 5
-  
+
         self.table = Table(self.name, self.num_columns, self.key)
 
         self.assertEqual(self.table.name, "grades")
-        self.assertEqual(self.table.key, 1234)
-        self.assertEqual(self.table.num_columns, 10)
-        self.assertEqual(self.table.page_directory.num_columns, 10)
+        self.assertEqual(self.table.key, 0)
+        self.assertEqual(self.table.num_columns, 9)
+        self.assertEqual(self.table.page_directory.num_columns, 9)
         self.assertEqual(self.table.page_directory.currPageRangeIndex, 0)
         self.assertEqual(self.table.index.table, self.table)
         self.assertEqual(self.table.latestRID, None)
         self.assertEqual(self.table.currPageRangeIndex, 0)
 
     def test_table_getRecord(self):
-        self.table.createNewRecord(1234,[5,6,7,8,9])
+        self.table.createNewRecord(0, [123456, 6, 7, 8, 9])
 
         record = self.table.getRecord(100000000)
 
-        self.assertEqual(record.key, 1234)
+        self.assertEqual(record.key, 123456)
         self.assertEqual(record.indirection, 0)
         # self.assertEqual(record.timestamp, 100000000)
         self.assertEqual(record.encoding, 0)
-        self.assertEqual(record.columns, [5,6,7,8,9])
+        self.assertEqual(record.columns, [5, 6, 7, 8, 9])
         self.assertEqual(record.RID, 100000000)
 
     def test_table_createNewRecord(self):
         numOfRecordsAdded = 10000
-        values = [0,0,0,0,0]
-        
-        for i in range(0,numOfRecordsAdded):
-            values = [0,0,0,0,1 + i]
-            self.table.createNewRecord(i+1, values)
+        values = [0, 0, 0, 0, 0]
 
-        #10000 records created, with 10 total columns
+        for i in range(0, numOfRecordsAdded):
+            values = [0, 0, 0, 0, 1 + i]
+            self.table.createNewRecord(i + 1, values)
+
+        # 10000 records created, with 10 total columns
         # page = 1000 records
         # 2000 records per pageRange
         # each page range can hold 2 sets of physical pages -> 
@@ -52,39 +53,39 @@ class TestTableFunctionality(unittest.TestCase):
         numOfPageRanges = len(pageRanges)
         pageRangeCapacity = self.table.page_directory.pageRanges[0].getPageRangeCapacity()
 
-        #I think this is right
+        # I think this is right
         expectedNumOfPageRanges = math.floor((numOfRecordsAdded / PAGE_SIZE) / pageRangeCapacity)
 
         self.assertEqual(numOfPageRanges, expectedNumOfPageRanges)
 
-        #loop through table.pagedirectories base pages
+        # loop through table.pagedirectories base pages
         for i in range(0, numOfPageRanges):
             basePages = pageRanges[i].basePages
 
             self.assertEqual(len(basePages), pageRangeCapacity)
 
-            #loop through each basePage/ set of Physical pages
+            # loop through each basePage/ set of Physical pages
             for i in range(0, len(basePages)):
                 physicalPages = basePages[i]
 
                 self.assertEqual(len(physicalPages.physicalPages), RECORD_COLUMN_OFFSET + len(values))
 
-        #spot check random ids-------------------------- will only work for the 5 column format
-        #record: 500 -> 1 00 00 0499
+        # spot check random ids-------------------------- will only work for the 5 column format
+        # record: 500 -> 1 00 00 0499
         record = self.table.getRecord(100000499)
         RID = record.RID
         fifthColItem = record.columns[4]
         self.assertEqual(fifthColItem, 500)
         self.assertEqual(RID, 100000499)
 
-        #record: 1000 -> 1 00 00 0999
+        # record: 1000 -> 1 00 00 0999
         record = self.table.getRecord(100000999)
         RID = record.RID
         fifthColItem = record.columns[4]
         self.assertEqual(fifthColItem, 1000)
         self.assertEqual(RID, 100000999)
 
-        #record: 1001 -> 1 00 01 0000
+        # record: 1001 -> 1 00 01 0000
         record = self.table.getRecord(100010000)
         RID = record.RID
         fifthColItem = record.columns[4]
@@ -97,46 +98,45 @@ class TestTableFunctionality(unittest.TestCase):
         fifthColItem = record.columns[4]
         self.assertEqual(fifthColItem, 2001)
         self.assertEqual(RID, 101000000)
-        
-        #record: 2600 -> 1 01 00 0599
+
+        # record: 2600 -> 1 01 00 0599
         record = self.table.getRecord(101000599)
         RID = record.RID
         fifthColItem = record.columns[4]
         self.assertEqual(fifthColItem, 2600)
         self.assertEqual(RID, 101000599)
 
-        #record: 7999 -> 1 03 01 0998
+        # record: 7999 -> 1 03 01 0998
         record = self.table.getRecord(103010998)
         RID = record.RID
         fifthColItem = record.columns[4]
         self.assertEqual(fifthColItem, 7999)
         self.assertEqual(RID, 103010998)
 
-        #record 8000 -> 1 03 01 0999
+        # record 8000 -> 1 03 01 0999
         record = self.table.getRecord(103010999)
         RID = record.RID
         fifthColItem = record.columns[4]
         self.assertEqual(fifthColItem, 8000)
         self.assertEqual(RID, 103010999)
 
-        #record 8001 -> 1 04 00 0000
+        # record 8001 -> 1 04 00 0000
         record = self.table.getRecord(104000000)
         RID = record.RID
         fifthColItem = record.columns[4]
         self.assertEqual(fifthColItem, 8001)
         self.assertEqual(RID, 104000000)
 
-        #record: 10000 -> 1 04 01 0999
+        # record: 10000 -> 1 04 01 0999
         record = self.table.getRecord(104010999)
         RID = record.RID
         fifthColItem = record.columns[4]
         self.assertEqual(fifthColItem, 10000)
         self.assertEqual(RID, 104010999)
 
-
     def test_table_updateRecord(self):
         self.table.updateRecord(1234, 100000000, [None, None, None, None, 906659671])
-        
+
         updatedBaseRecord = self.table.getRecord(100000000)
         self.assertEqual(updatedBaseRecord.encoding, 1)
         self.assertNotEquals(updatedBaseRecord.indirection, 0)
@@ -149,11 +149,11 @@ class TestTableFunctionality(unittest.TestCase):
         self.assertEqual(tailRecord.columns, expectedValues)
 
     def test_table_getUpdatedRow(self):
-        currValues = [1,2,3,4,5]
+        currValues = [1, 2, 3, 4, 5]
         updateRequest = [10, None, None, 100000000, None]
-        expected = [10,2,3,100000000,5]
+        expected = [10, 2, 3, 100000000, 5]
 
-        updatedResponse = self.table.getUpdatedRow(currValues,updateRequest)
+        updatedResponse = self.table.getUpdatedRow(currValues, updateRequest)
 
         self.assertEqual(expected, updatedResponse)
 

--- a/template/query.py
+++ b/template/query.py
@@ -1,4 +1,4 @@
-from template.table import Table, Record
+from template.table import *
 from template.index import Index
 from template.config import *
 
@@ -110,7 +110,7 @@ class Query:
         try:
             for rid in ridRange:
                 record = self.table.getRecord(rid)
-                value = record.columns[aggregate_column_index]
+                value = record.columns[aggregate_column_index - RECORD_COLUMN_OFFSET]
                 sum += value
             return sum
         except:

--- a/template/table.py
+++ b/template/table.py
@@ -68,7 +68,7 @@ class Table:
         RID = physicalPages.physicalPages[RID_COLUMN].getRecord(locPhyPageIndex)
         timeStamp = physicalPages.physicalPages[TIMESTAMP_COLUMN].getRecord(locPhyPageIndex)
         encoding = physicalPages.physicalPages[SCHEMA_ENCODING_COLUMN].getRecord(locPhyPageIndex)
-        key = physicalPages.physicalPages[KEY_COLUMN].getRecord(locPhyPageIndex)
+        key = physicalPages.physicalPages[self.key + RECORD_COLUMN_OFFSET].getRecord(locPhyPageIndex)
 
         columns = []
 
@@ -180,7 +180,6 @@ class PhysicalPages:
         self.physicalPages[RID_COLUMN].write(RID)
         self.physicalPages[TIMESTAMP_COLUMN].write(record.timestamp)
         self.physicalPages[SCHEMA_ENCODING_COLUMN].write(record.encoding)
-        self.physicalPages[KEY_COLUMN].write(record.key)
 
         for col in range(RECORD_COLUMN_OFFSET, RECORD_COLUMN_OFFSET + len(record.columns)):
             columnData = record.columns[col - RECORD_COLUMN_OFFSET]


### PR DESCRIPTION
## Changes
- removed KEY_COLUMN from table.py
- adjusted unit tests for KEY_COLUMN removal
- accounted for RECORD_COLUMN_OFFSET in record retrieval for query.sum()
- reformatting in table_tester.py because PyCharm wanted it