### PR TITLE
Completed Merge

### DIFF
--- a/m2_tester_part2.py
+++ b/m2_tester_part2.py
@@ -28,7 +28,6 @@ for _ in range(10):
 keys = sorted(list(records.keys()))
 for key in keys:
     print(records[key])
-    print(records[key])
 
 for key in keys:
     record = query.select(key, 0, [1, 1, 1, 1, 1])[0]

--- a/template/MergeThread.py
+++ b/template/MergeThread.py
@@ -42,17 +42,17 @@ class MergeThread(threading.Thread):
         self.exit_request.clear()
 
         while not self.exit_request.isSet():
-            time.sleep(self.interval)
-            print('\nInitiating a merge...')
-            self.db.merge_placeholder()  # placeholder for db merge method
 
-        """
-        trigger merge based on either a) time or b) unmergedTailRecords threshold
-        get table_name and PRidx from buffer_pool
-        merge all tail pages in that PR
-        reset number of unmerged tail records belonging to that table_name.PR to 0
-        """
-        # call buffer_pool.resetTailPageRecordCount(table_name, page_range_index)
+            print('\nInitiating a merge...')
+            table_name, page_range_index = self.db.bufferPool.getPageRangeForMerge()  # get the info to start a merge
+            if table_name == "empty":  # change this statement
+                # there are no PageRanges to do a merge, ignore and wait
+                pass
+            else:
+                # have PR to merge, start merge
+                self.db.merge(table_name, page_range_index)
+
+            time.sleep(self.interval)
 
     def stop_thread(self):
         """

--- a/template/MergeThread.py
+++ b/template/MergeThread.py
@@ -46,6 +46,15 @@ class MergeThread(threading.Thread):
             print('\nInitiating a merge...')
             self.db.merge_placeholder()  # placeholder for db merge method
 
+        """
+        trigger merge based on either a) time or b) unmergedTailRecords threshold
+        sort buffer_pool.merge_queue by number of unmerged tail records
+        grab head from queue
+        head has table_name and PR to merge on
+        merge all tail pages in that PR
+        reset number of unmerged tail records belonging to that table_name.PR to 0
+        """
+
     def stop_thread(self):
         """
         sets the exit_request event flag to True so thread will terminate asap

--- a/template/MergeThread.py
+++ b/template/MergeThread.py
@@ -1,7 +1,6 @@
 import threading
 import time
 
-from template.db import Database
 
 
 class MergeThread(threading.Thread):
@@ -13,7 +12,7 @@ class MergeThread(threading.Thread):
     until the application exits OR the db is closed.
     """
 
-    def __init__(self, db: Database, interval=1):
+    def __init__(self, db, interval=1):
         """
         MergeThread Constructor
 

--- a/template/MergeThread.py
+++ b/template/MergeThread.py
@@ -32,12 +32,12 @@ class MergeThread(threading.Thread):
 
     def thread_start(self):
         """
-        Starts merge thread when called instead of when initialized
+        Starts merge thread when called instead of when initialized. Call when opening the Database.
         """
         self.thread.start()  # Start the execution
 
     def run(self):
-        """ Method that runs forever """
+        """ Method that begins waiting and merging within the Database """
 
         self.exit_request.clear()
 
@@ -48,15 +48,14 @@ class MergeThread(threading.Thread):
 
         """
         trigger merge based on either a) time or b) unmergedTailRecords threshold
-        sort buffer_pool.merge_queue by number of unmerged tail records
-        grab head from queue
-        head has table_name and PR to merge on
+        get table_name and PRidx from buffer_pool
         merge all tail pages in that PR
         reset number of unmerged tail records belonging to that table_name.PR to 0
         """
+        # call buffer_pool.resetTailPageRecordCount(table_name, page_range_index)
 
     def stop_thread(self):
         """
-        sets the exit_request event flag to True so thread will terminate asap
+        Sets the exit_request event flag to True so thread will terminate asap. Call when closing the Database.
         """
         self.exit_request.set()  # set event flag to True

--- a/template/MergeThread.py
+++ b/template/MergeThread.py
@@ -1,6 +1,8 @@
 import threading
 import time
 
+from template.db import Database
+
 
 class MergeThread(threading.Thread):
     """
@@ -11,7 +13,7 @@ class MergeThread(threading.Thread):
     until the application exits OR the db is closed.
     """
 
-    def __init__(self, db, interval=1):
+    def __init__(self, db: Database, interval=1):
         """
         MergeThread Constructor
 
@@ -44,13 +46,12 @@ class MergeThread(threading.Thread):
         while not self.exit_request.isSet():
 
             print('\nInitiating a merge...')
-            table_name, page_range_index = self.db.bufferPool.getPageRangeForMerge()  # get the info to start a merge
-            if table_name == "empty":  # change this statement
-                # there are no PageRanges to do a merge, ignore and wait
-                pass
-            else:
+            merge_data = self.db.bufferPool.getPageRangeForMerge()  # get the info to start a merge
+
+            if merge_data is not True:  # PR to merge
                 # have PR to merge, start merge
-                self.db.merge(table_name, page_range_index)
+                self.db.merge(table_name=merge_data[0], page_range_index=merge_data[1])
+            # else: merge_data is True so no PRs to merge
 
             time.sleep(self.interval)
 

--- a/template/buffer_pool.py
+++ b/template/buffer_pool.py
@@ -56,6 +56,10 @@ class BufferPool:
         sorted_tailRecordsSinceLastMerge = copy.deepcopy(self.tailRecordsSinceLastMerge)
         sorted_tailRecordsSinceLastMerge.sort(key=lambda x: x[2])
 
+        # Don't need to merge
+        if len(sorted_tailRecordsSinceLastMerge) == 0:
+            return True
+
         # get the greatest num of tailRecordsSinceLastMerge
         greastestNumOfTailRecs = sorted_tailRecordsSinceLastMerge[-1]
 

--- a/template/buffer_pool.py
+++ b/template/buffer_pool.py
@@ -28,7 +28,7 @@ class BufferPool:
         # DB initializes a value every time a new table gets created
         self.numOfColumns = {}
 
-        #list of [tableName, PR_index_rel_to_table, tailRecordsSinceLastMerge]
+        # list of [tableName, PR_index_rel_to_table, tailRecordsSinceLastMerge]
         self.tailRecordsSinceLastMerge = []
 
         """ 
@@ -52,24 +52,24 @@ class BufferPool:
     # if nothing to merge return True 
     """
     def getPageRangeForMerge(self):
-        #sort the list of lists by 3rd element: tailRecordsSinceLastMerge
-        sorted_tailRecordsSinceLastMerge = copy.deepcopy(self.sorted_tailRecordsSinceLastMerge)
+        # sort the list of lists by 3rd element: tailRecordsSinceLastMerge
+        sorted_tailRecordsSinceLastMerge = copy.deepcopy(self.tailRecordsSinceLastMerge)
         sorted_tailRecordsSinceLastMerge.sort(key=lambda x: x[2])
 
-        #get the greatest num of tailRecordsSinceLastMerge
-        greastestNumOfTailRecs = self.sorted_tailRecordsSinceLastMerge[-1]
+        # get the greatest num of tailRecordsSinceLastMerge
+        greastestNumOfTailRecs = sorted_tailRecordsSinceLastMerge[-1]
 
-        #Don't need to do merge if no changes have been made to tail records
+        # Don't need to do merge if no changes have been made to tail records
         if greastestNumOfTailRecs[2] == 0:
             return True
 
-        #get TableName and page range index
-        return self.greastestNumOfTailRecs[0:2]
+        # get TableName and page range index
+        return greastestNumOfTailRecs[0:2]
 
     """
     get the desired index in tailRecordsSinceLastMerge based off the params
     """
-    def get_tailRecordsSinceLastMerge_index(self,table_name, page_range_index):
+    def get_tailRecordsSinceLastMerge_index(self, table_name, page_range_index):
 
         for i in range(len(self.tailRecordsSinceLastMerge)):
             curr = self.tailRecordsSinceLastMerge[i]

--- a/template/buffer_pool.py
+++ b/template/buffer_pool.py
@@ -63,8 +63,8 @@ class BufferPool:
         # get the greatest num of tailRecordsSinceLastMerge
         greastestNumOfTailRecs = sorted_tailRecordsSinceLastMerge[-1]
 
-        # Don't need to do merge if no changes have been made to tail records
-        if greastestNumOfTailRecs[2] == 0:
+        # Don't need to do merge if less than 100 tail records
+        if greastestNumOfTailRecs[2] <= 100:
             return True
 
         # get TableName and page range index
@@ -84,7 +84,8 @@ class BufferPool:
         return False
 
     def resetTailPageRecordCount(self, table_name, page_range_index):
-        index = self.get_page_range_index_in_buffer_pool(table_name, page_range_index)
+        index = self.get_tailRecordsSinceLastMerge_index(table_name, page_range_index)
+
         self.tailRecordsSinceLastMerge[index][2] = 0
 
     def setDatabaseLocation(self, path: str):

--- a/template/db.py
+++ b/template/db.py
@@ -42,8 +42,8 @@ class Database:
                 self.tables.append(Table(table_name, int(num_columns), int(key_column), self.bufferPool))
 
     def close(self):
-        self.bufferPool.save(self.tables)
         self.merge_thread.stop_thread()  # prompts the thread to finish and terminate
+        self.bufferPool.save(self.tables)
 
     """
     # Creates a new table
@@ -131,7 +131,7 @@ class Database:
             # deepcopy() is used to copy an object and child objects within it
             # copy() shallow copies an object but its children are references to the original
             consolidated_BP.numOfRecords = copy.deepcopy(orig_bp.numOfRecords)
-            for j in enumerate(consolidated_BP.physicalPages):
+            for j in range(len(consolidated_BP.physicalPages)):
                 if j != INDIRECTION_COLUMN:
                     consolidated_BP.physicalPages[j] = copy.deepcopy(orig_bp.physicalPages[j])
 
@@ -152,11 +152,13 @@ class Database:
         # TODO: only reverse iterate until reaching the latest merged tail record
         #  not all the tail records
         # reverse iterate over all tail pages in Page Range
-        for page_num, tail_page in reversed(list(enumerate(range_to_merge.tailPages))):
+        for item in reversed(list(enumerate(range_to_merge.tailPages))):
+            page_num = item[0]
+            tail_page = item[1]
             tail_page_records = tail_page.getAllRecords()
 
             # reverse iterate over all records within this tail page
-            for i, record in reversed(tail_page_records):
+            for i, record in enumerate(reversed(tail_page_records)):
                 if not record[BASE_RID_COLUMN] in seenUpdatesSet:
                     # add the BaseRID as the key to the "hashmap"
                     seenUpdatesSet.add(record[BASE_RID_COLUMN])

--- a/template/physical_pages.py
+++ b/template/physical_pages.py
@@ -40,6 +40,45 @@ class PhysicalPages:
 
         return RID
 
+    def getPageRecord(self, record_index):
+        """
+        :param record_index: index of a record in the page (0-999)
+        :return: List of int of length num_columns + RECORD_COLUMN_OFFSET
+        """
+        record = []
+
+        for i in range(len(self.physicalPages)):
+            record.append(self.physicalPages[i].getRecord(record_index))
+
+        return record
+
+    def getAllRecords(self):
+        """
+        :return: List of records (which are lists containing int)
+        """
+        page_records = []
+
+        for record_index in range(self.numOfRecords):
+            page_records.append(self.getPageRecord(record_index))
+
+        return page_records
+
+    def replaceRecord(self, record_index, record):
+        """
+        Replaces the values of a record for all data pages.
+
+        :type record_index: int
+        :param record_index: index within the page to replace at
+        :type record: list
+        :param record: List of size num_columns + RECORD_COLUMN_OFFSET
+        """
+
+        # do not replace meta data record values
+        # note: possible point of failure here
+        for col, page in enumerate(self.physicalPages):
+            if col >= RECORD_COLUMN_OFFSET:
+                self.physicalPages[col].replaceRecord(record_index, record[col])
+
     def hasCapacity(self):
         if self.numOfRecords >= PAGE_SIZE:
             #page is full


### PR DESCRIPTION
- implemented a MergeThread for background, contention-free merges
- implemented a merge function that runs on PageRanges with more than 100 updated tail records
- Buffer Pool tracks tail record changes and serves table_name, page_range_index, and # of updated tail records to MergeThread
- Works for 10,000 records in the m2 testers